### PR TITLE
Remove margin bottom in text primitives

### DIFF
--- a/src/components/Blockquote/Blockquote.styles.tsx
+++ b/src/components/Blockquote/Blockquote.styles.tsx
@@ -5,7 +5,7 @@ export const BlockquoteWrapper = styled('blockquote', {
   /**
    * Make it fullbleed!
    */
-  margin: '0 -50vw 2.25rem -50vw',
+  margin: '0 -50vw 0 -50vw',
   position: 'relative',
   left: '50%',
   right: '50%',

--- a/src/components/Callout/Callout.styles.tsx
+++ b/src/components/Callout/Callout.styles.tsx
@@ -49,13 +49,8 @@ export const StyledCalloutLabelWrapper = styled('div', {
 });
 
 export const StyledCallout = styled('aside', {
-  '*:last-child': {
-    marginBottom: '0px',
-  },
-
   position: 'relative',
   padding: '30px 30px',
-  marginBottom: '2.25rem',
   borderRadius: 'var(--border-radius-1)',
   color: 'var(--maximeheckel-colors-typeface-primary)',
   border: '1px solid var(--maximeheckel-colors-emphasis)',

--- a/src/components/Callout/Callout.types.ts
+++ b/src/components/Callout/Callout.types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CSS } from 'src/lib/stitches.config';
 
 export type CalloutVariant = 'info' | 'danger';
 
@@ -6,4 +7,5 @@ export interface CalloutProps {
   children: React.ReactNode;
   label?: React.ReactNode | string;
   variant: CalloutVariant;
+  css?: CSS;
 }

--- a/src/components/Details/Details.tsx
+++ b/src/components/Details/Details.tsx
@@ -51,7 +51,7 @@ const Details = (props: DetailsProps) => {
 
   return (
     <CollapsibleRoot asChild open={open}>
-      <Card data-card-details>
+      <Card css={{ width: '100%' }} data-card-details>
         <details ref={detailsRef}>
           {SummaryComponent}
           <CollapsibleContent ref={contentRef}>{rest}</CollapsibleContent>

--- a/src/components/Details/Details.tsx
+++ b/src/components/Details/Details.tsx
@@ -51,7 +51,7 @@ const Details = (props: DetailsProps) => {
 
   return (
     <CollapsibleRoot asChild open={open}>
-      <Card css={{ marginBottom: '2.25rem' }} data-card-details>
+      <Card data-card-details>
         <details ref={detailsRef}>
           {SummaryComponent}
           <CollapsibleContent ref={contentRef}>{rest}</CollapsibleContent>

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -11,7 +11,6 @@ const Label = (props: React.LabelHTMLAttributes<HTMLLabelElement>) => {
         cursor: 'pointer',
         userSelect: 'none',
         marginRight: '8px',
-        marginBottom: '0px',
         letterSpacing: '0px',
         verticalAlign: 'top',
       }}

--- a/src/components/List/List.styles.tsx
+++ b/src/components/List/List.styles.tsx
@@ -30,7 +30,7 @@ export const StyledListItem = styled('li', {
 });
 
 export const StyledList = styled('div', {
-  margin: '0 0 1.45rem 0',
+  margin: 0,
   padding: '0',
   color: 'inherit',
   listStylePosition: 'outside',

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -18,16 +18,7 @@ const TextArea = React.forwardRef(
 
     return (
       <div>
-        {label ? (
-          <Label
-            htmlFor={id}
-            style={{
-              marginBottom: '8px',
-            }}
-          >
-            {label}
-          </Label>
-        ) : null}
+        {label ? <Label htmlFor={id}>{label}</Label> : null}
         <StyledTextArea
           id={id}
           disabled={disabled}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -29,16 +29,7 @@ const TextInput = (props: TextInputProps) => {
 
   return (
     <StyledInputWrapper className={isValid ? 'valid' : ''} variant={type}>
-      {label ? (
-        <Label
-          htmlFor={id}
-          style={{
-            marginBottom: '8px',
-          }}
-        >
-          {label}
-        </Label>
-      ) : null}
+      {label ? <Label htmlFor={id}>{label}</Label> : null}
       <Box css={{ position: 'relative' }}>
         <StyledInput
           id={id}

--- a/src/components/Typography/TypographyHeading.tsx
+++ b/src/components/Typography/TypographyHeading.tsx
@@ -24,25 +24,21 @@ const Heading = (props: HeadingProps) => {
       fontWeight: 'var(--font-weight-4)',
       lineHeight: '1.6818',
       letterSpacing: '0px',
-      marginBottom: '1.45rem',
     },
     2: {
       fontWeight: 'var(--font-weight-4)',
       lineHeight: '1.6818',
       letterSpacing: '0px',
-      marginBottom: '1.45rem',
     },
     3: {
       fontWeight: 'var(--font-weight-4)',
       lineHeight: '1.6818',
       letterSpacing: '0px',
-      marginBottom: '1.45rem',
     },
     4: {
       fontWeight: 'var(--font-weight-4)',
       lineHeight: '1.6818',
       letterSpacing: '0px',
-      marginBottom: '1.45rem',
     },
   };
 

--- a/src/components/Typography/TypographyText.tsx
+++ b/src/components/Typography/TypographyText.tsx
@@ -15,7 +15,7 @@ import { EMProps, StrongProps } from './Typography.types';
  */
 
 const Text = styled('span', {
-  margin: '0 0 2.25rem 0',
+  margin: 0,
   padding: 0,
   textRendering: 'optimizeLegibility',
 


### PR DESCRIPTION
Quality of life improvement: the default marginBottom was more annoying than useful (at least way less than originally thought) -> thus I'm nuking it.